### PR TITLE
fix crash if class is 0x0

### DIFF
--- a/Dynamic Code Injection/dyci/Classes/Notifications/SFInjectionsNotificationsCenter.m
+++ b/Dynamic Code Injection/dyci/Classes/Notifications/SFInjectionsNotificationsCenter.m
@@ -48,6 +48,9 @@
 
 
 - (void)addObserver:(id<SFInjectionObserver>)observer forClass:(Class)class {
+    if (!class) {
+        return;
+    }
     @synchronized (_observers) {
         NSMutableSet * observersPerClass = [_observers objectForKey:class];
         if (!observersPerClass) {


### PR DESCRIPTION
if class is null, have `'NSInvalidArgumentException', reason: '*** setObjectForKey: key cannot be nil'`
