### PR TITLE
Updated Podspec to pass Cocoapods validation

### DIFF
--- a/dyci.podspec
+++ b/dyci.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
 
   s.author       = { "Paul Taykalo" => "tt.kilew@gmail.com" }
 
-  s.source       = { :git => "https://github.com/olegam/dyci-main.git", :tag => 'v0.1.5.4'}
+  s.source       = { :git => "https://github.com/DyCI/dyci-main.git", :tag => 'v0.1.5.4'}
   s.requires_arc = true
   s.platform     = :ios, '5.0'
   s.source_files = 'Dynamic Code Injection/dyci/**/*.{h,m}'


### PR DESCRIPTION
I pushed a Podspec to the Cocoapods trunk pointing to my fork. When this PR has been accepted and the tag v0.1.5.4 has been created I can push the Podspec contained here pointing at the original repo. Sorry for the mess but I could not figure out a better way to do this where I would be able to test if it works.

You can already now update your Podfile to

```
pod 'dyci'
```

and enjoy not having to download dyci every time you run `pod install`.

https://github.com/DyCI/dyci-main/issues/37
