### PR TITLE
NSNotification letting anyone observe for injection

### DIFF
--- a/Dynamic Code Injection/dyci/Classes/Notifications/SFInjectionsNotificationsCenter.h
+++ b/Dynamic Code Injection/dyci/Classes/Notifications/SFInjectionsNotificationsCenter.h
@@ -11,9 +11,21 @@
 #if TARGET_IPHONE_SIMULATOR
 
 /*
- notification.object will be the class that was injected
+ 
+ You can observe for changes in any class by saying
+
+ #if TARGET_IPHONE_SIMULATOR
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(classInjectionNotification:) name:@"SFInjectionsClassInjectedNotification" object:nil];
+ #endif
+ 
+ Or by specifying a specific class
+
+ #if TARGET_IPHONE_SIMULATOR
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(myViewControllerClassInjectionNotification:) name:@"SFInjectionsClassInjectedNotification" object:(id)[MyViewController class]];
+ #endif
+ 
  */
-extern NSString * const SFInjectionsClassInjectedNotification;
+
 
 @protocol SFInjectionObserver <NSObject>
 

--- a/Dynamic Code Injection/dyci/Classes/Notifications/SFInjectionsNotificationsCenter.m
+++ b/Dynamic Code Injection/dyci/Classes/Notifications/SFInjectionsNotificationsCenter.m
@@ -10,7 +10,18 @@
 
 #if TARGET_IPHONE_SIMULATOR
 
+/*
+ notification.object will be the class that was injected
+ This notification is private due to discussion here https://github.com/DyCI/dyci-main/pull/51
+ */
 NSString * const SFInjectionsClassInjectedNotification = @"SFInjectionsClassInjectedNotification";
+
+/*
+ notification.object will be the resource that was injected
+ This notification is private due to discussion here https://github.com/DyCI/dyci-main/pull/51
+ */
+NSString * const SFInjectionsResourceInjectedNotification = @"SFInjectionsResourceInjectedNotification";
+
 
 @implementation SFInjectionsNotificationsCenter {
     NSMutableDictionary * _observers;
@@ -99,6 +110,9 @@ This will notify about class injection
 This will notiy all registered classes about that some resource was injected
  */
 - (void)notifyOnResourceInjection:(NSString *)resourceInjection {
+
+    [[NSNotificationCenter defaultCenter] postNotificationName:SFInjectionsResourceInjectedNotification object:resourceInjection];
+
     int idx = 0;
     @synchronized (_observers) {
         for (NSMutableSet * observersPerClass in [_observers allValues]) {


### PR DESCRIPTION
This is especially useful if there are some classes that is difficult to reset and simple to recreate. 

Example: a controller has 10 different table view cells. It can be easier to rebuild the table view than to update each cell. 
