### PR TITLE
Retain class observers

### DIFF
--- a/Dynamic Code Injection/dyci/Classes/Notifications/SFInjectionsNotificationsCenter.m
+++ b/Dynamic Code Injection/dyci/Classes/Notifications/SFInjectionsNotificationsCenter.m
@@ -68,13 +68,13 @@ NSString * const SFInjectionsResourceInjectedNotification = @"SFInjectionsResour
         return;
     }
     @synchronized (_observers) {
-        NSMutableSet * observersPerClass = [_observers objectForKey:aClass];
+        CFMutableSetRef observersPerClass = (__bridge CFMutableSetRef)([_observers objectForKey:aClass]);
         if (!observersPerClass) {
-            observersPerClass = (__bridge_transfer NSMutableSet *) CFSetCreateMutable(nil, 0, nil);
-            [_observers setObject:observersPerClass forKey:aClass];
+            observersPerClass = CFSetCreateMutable(nil, 0, nil);
+            [_observers setObject:(__bridge_transfer NSMutableSet *) observersPerClass forKey:aClass];
         }
-        @synchronized (observersPerClass) {
-            [observersPerClass addObject:observer];
+        @synchronized ((__bridge id)observersPerClass) {
+            CFSetSetValue(observersPerClass, (__bridge_retained void*) observer);
         }
     }
 }


### PR DESCRIPTION
Observers are referenced as __unsafe_unretained, but sometimes observers released, leading to crash on notification. Fix this by retaining observers.

Other approach may be keeping week references to observers, but i've took simple way :)