### PR TITLE
Signing of compiled binary in dyci-recompile.py

### DIFF
--- a/Scripts/dyci-recompile.py
+++ b/Scripts/dyci-recompile.py
@@ -219,8 +219,17 @@ linkArgs = \
 + ["-current_version"]\
 + ["5"]\
 + ["-o"]\
-+ [DYCI_ROOT_DIR + "/" + libraryName]
++ [DYCI_ROOT_DIR + "/tmp/" + libraryName]\
 #       + ['-v']
 
-#print "Linker arks \n%s" % ' '.join(linkArgs)
+# print "Linker args \n%s" % ' '.join(linkArgs)
 runAndFailOnError(linkArgs)
+print "Linked\n"
+
+#sign
+signArgs = ["/usr/bin/codesign"] + ["-s"] + ["-"] + ["-vvvv"] + ["-f"] + [DYCI_ROOT_DIR + "/tmp/" + libraryName]
+runAndFailOnError(signArgs)
+print "Signed " + libraryName + "\n"
+
+moveArgs = ["mv", DYCI_ROOT_DIR + "/tmp/" + libraryName, DYCI_ROOT_DIR + "/" + libraryName]
+runAndFailOnError(moveArgs)


### PR DESCRIPTION
Had to move the original compiled binary to the tmp subdirectory since the compilation triggers the file change event and iOS application tries to load a not yet signed binary. 
This fixes #111 for AppCode.